### PR TITLE
feat: add branch strategy and PR approval workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,35 @@ The blog works perfectly with local Markdown files in `content/posts/`. Strapi i
 
 ---
 
+## Contributing (Branch Strategy)
+
+The `main` branch is **protected**. All changes must go through a Pull Request with owner approval.
+
+```text
+main (protected)        ← production, deploys to GitHub Pages
+  └── feature/<name>    ← new features
+  └── fix/<name>        ← bug fixes
+  └── docs/<name>       ← documentation changes
+```
+
+### Workflow
+
+1. Create a feature branch from `main`: `git checkout -b feature/<name>`
+2. Make changes and commit
+3. Push the branch: `git push origin feature/<name>`
+4. Open a Pull Request to `main`
+5. Wait for CI to pass and owner approval
+6. Merge after approval
+
+### Branch Protection Rules
+
+- PR required with **1 approving review**
+- **CI must pass** (`build` job)
+- Stale reviews are dismissed on new commits
+- Enforced for admins
+
+---
+
 ## Author
 
 **Younjin Jeong (RYONGJIN)**


### PR DESCRIPTION
## Summary

- Added branch protection rules on `main` (PR required, 1 approval, CI must pass)
- Added Contributing section to README with branch model and workflow
- Updated CLAUDE.md (local) with agent-specific branch rules

## Changes

- **README.md**: New "Contributing (Branch Strategy)" section with branch model, workflow steps, and protection rules
- **CLAUDE.md** (local, not in git): Branch rules for all agents
- **GitHub branch protection**: Enabled on `main` via API

## Branch Protection Settings

| Rule | Value |
|------|-------|
| Required PR reviews | 1 |
| Dismiss stale reviews | Yes |
| Required status checks | `build` (strict) |
| Enforce admins | Yes |
| Force push | Blocked |
| Branch deletion | Blocked |

## Test plan

- [ ] Verify direct push to `main` is blocked
- [ ] Verify PR requires approval before merge
- [ ] Verify CI (`build` job) runs on the PR

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)