### PR TITLE
feat: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,20 @@
+name: Gitleaks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global allowlist"
+paths = [
+  '''\.git/''',
+  '''public/''',
+  '''node_modules/''',
+  '''themes/''',
+  '''.env\.example''',
+]
+regexTarget = "match"
+regexes = [
+  '''younjin\.jeong@gmail\.com''',
+]


### PR DESCRIPTION
## Summary
- Adds gitleaks GitHub Action workflow to scan for leaked credentials/secrets on every push and PR to main
- Adds `.gitleaks.toml` config with:
  - Default rules (AWS keys, GCP keys, GitHub tokens, generic passwords, etc.)
  - Allowlist for `younjin.jeong@gmail.com`
  - Skips `public/`, `node_modules/`, `themes/`, `.env.example`

## Test plan
- [ ] Gitleaks workflow runs successfully on this PR
- [ ] No false positives on existing codebase
- [ ] Author email is not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)